### PR TITLE
Fix for vendor build failure

### DIFF
--- a/backend/e4h-services/vendor-registry/src/test/java/org/egov/web/controllers/OrganisationApiControllerTest.java
+++ b/backend/e4h-services/vendor-registry/src/test/java/org/egov/web/controllers/OrganisationApiControllerTest.java
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -57,6 +58,9 @@ import org.junit.jupiter.api.Test;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = OrganizationMain.class, properties = "spring.main.lazy-initialization=true")
 @AutoConfigureMockMvc
+@EnableAutoConfiguration(exclude = {
+    io.opentelemetry.instrumentation.spring.autoconfigure.OpenTelemetryAutoConfiguration.class
+})
 class OrganisationApiControllerTest {
 
     @Autowired


### PR DESCRIPTION
Added an annotation to ignore telemetry config in unit tests.