### PR TITLE
Added more exclusions to disable telemetry config for unit tests

### DIFF
--- a/backend/e4h-services/vendor-registry/src/test/java/org/egov/web/controllers/OrgServicesApiControllerTest.java
+++ b/backend/e4h-services/vendor-registry/src/test/java/org/egov/web/controllers/OrgServicesApiControllerTest.java
@@ -22,6 +22,12 @@ import org.egov.TestConfiguration;
 @RunWith(SpringRunner.class)
 @WebMvcTest(OrgServicesApiController.class)
 @Import(TestConfiguration.class)
+@EnableAutoConfiguration(exclude = {
+    io.opentelemetry.instrumentation.spring.autoconfigure.OpenTelemetryAutoConfiguration.class,
+    org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration.class,
+    org.springframework.boot.actuate.autoconfigure.tracing.OpenTelemetryAutoConfiguration.class,
+    org.springframework.boot.actuate.autoconfigure.tracing.MicrometerTracingAutoConfiguration.class
+})
 public class OrgServicesApiControllerTest {
 
     @Autowired

--- a/backend/e4h-services/vendor-registry/src/test/java/org/egov/web/controllers/OrganisationApiControllerTest.java
+++ b/backend/e4h-services/vendor-registry/src/test/java/org/egov/web/controllers/OrganisationApiControllerTest.java
@@ -56,10 +56,18 @@ import org.junit.jupiter.api.Test;
 //import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = OrganizationMain.class, properties = "spring.main.lazy-initialization=true")
+SpringBootTest(classes = OrganizationMain.class, properties = {
+    "spring.main.lazy-initialization=true",
+    "management.tracing.enabled=false",
+    "management.otlp.metrics.export.enabled=false",
+    "management.otlp.tracing.export.enabled=false"
+})
 @AutoConfigureMockMvc
 @EnableAutoConfiguration(exclude = {
-    io.opentelemetry.instrumentation.spring.autoconfigure.OpenTelemetryAutoConfiguration.class
+    io.opentelemetry.instrumentation.spring.autoconfigure.OpenTelemetryAutoConfiguration.class,
+    org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration.class,
+    org.springframework.boot.actuate.autoconfigure.tracing.OpenTelemetryAutoConfiguration.class,
+    org.springframework.boot.actuate.autoconfigure.tracing.MicrometerTracingAutoConfiguration.class
 })
 class OrganisationApiControllerTest {
 


### PR DESCRIPTION
MockMvc is trying to set up tracing as part of the test suite. Disabling it by adding some exclusions.