### PR TITLE
feat(analytics): add GA4 tracking for login, page views, and media interactions

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/baseParams.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/baseParams.js
@@ -1,0 +1,28 @@
+
+import { getSessionId } from './session';
+import { getUserRoleCsv, getGeography } from './context';
+
+const getDeviceType = () =>
+  window?.Digit?.Utils?.browser?.isMobile?.() ? 'mobile' : 'desktop';
+
+const getBrowser = () => {
+  const ua = navigator.userAgent;
+  if (ua.includes('Edg')) return 'Edge';
+  if (ua.includes('Chrome')) return 'Chrome';
+  if (ua.includes('Firefox')) return 'Firefox';
+  if (ua.includes('Safari')) return 'Safari';
+  return 'Other';
+};
+
+export function baseParams(extra = {}) {
+  const geo = getGeography();
+  return {
+    session_id: getSessionId(),
+    user_role: getUserRoleCsv(),
+    device_type: getDeviceType(),
+    browser: getBrowser(),
+    os: navigator.platform || 'unknown',
+    ...geo,
+    ...extra,
+  };
+}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/config.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/config.js
@@ -1,0 +1,5 @@
+export const GA_MEASUREMENT_ID =
+  process.env.REACT_APP_GA_ID || 'G-ZDFDM34WK4';
+
+export const IS_PROD = process.env.NODE_ENV === 'production';
+export const DEBUG_MODE = !IS_PROD;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/context.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/context.js
@@ -1,0 +1,24 @@
+
+export function getUserRoleCsv() {
+  try {
+    const roles = window?.Digit?.SessionStorage?.get('User')?.info?.roles || [];
+    return roles.map(r => r.code).join(',') || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+export function getGeography() {
+
+  const state = window?.Digit?.ULBService?.getStateId?.() || 'unknown';
+  const district = window?.Digit?.SessionStorage?.get('User')?.info?.district || 'unknown';
+  const block = window?.Digit?.SessionStorage?.get('User')?.info?.block || 'unknown';
+  const facility = window?.Digit?.SessionStorage?.get('User')?.info?.facilityName || 'unknown';
+
+  return {
+    geography_state: state,
+    geography_district: district,
+    geography_block: block,
+    facility_name: facility,
+  };
+}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/events.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/events.js
@@ -1,0 +1,17 @@
+
+export const EV = {
+  USER_LOGIN: "user_login",
+
+  PAGE_VIEW: "page_view",
+
+  BUTTON_CLICK: "button_click",
+
+  SUBMIT_TICKET: "submit_ticket",
+  UPLOAD_MEDIA: "upload_media",
+  STREAM_VIDEO: "stream_video",
+  DOWNLOAD_IMAGE: "download_image",
+
+  FILTER_USAGE: "filter_usage",
+
+  LANGUAGE_SELECTION: "language_selection",
+};

--- a/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/gtag.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/gtag.js
@@ -1,0 +1,41 @@
+
+import { GA_MEASUREMENT_ID, DEBUG_MODE } from './config';
+
+const queue = [];
+let ready = false;
+
+function flush() {
+  const g = window.gtag;
+  if (!g) return;
+  ready = true;
+  while (queue.length) g(...queue.shift());
+}
+
+export function loadGA() {
+  if (typeof window === 'undefined') return;
+  if (window.gtag) { ready = true; return; }
+
+  const s = document.createElement('script');
+  s.async = true;
+  s.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+  s.onload = () => {
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = function(){ window.dataLayer.push(arguments); };
+    window.gtag('js', new Date());
+    window.gtag('config', GA_MEASUREMENT_ID, {
+      anonymize_ip: true,
+      debug_mode: DEBUG_MODE
+    });
+    flush();
+    console.log('✅ GA loaded:', GA_MEASUREMENT_ID);
+  };
+  document.head.appendChild(s);
+}
+
+export function gtag(...args) {
+  if (ready && typeof window.gtag === 'function') {
+    window.gtag(...args);
+  } else {
+    queue.push(args);
+  }
+}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/index.js
@@ -1,0 +1,14 @@
+
+export { loadGA, gtag } from "./gtag";
+export { baseParams } from "./baseParams";
+export { getSessionId, wasLoginEventSent, markLoginEventSent } from "./session";
+export { getUserRoleCsv, getGeography } from "./context";
+export { EV } from "./events";
+export {
+  trackLogin,
+  trackPageView,
+  trackButtonClick,
+  trackSubmitTicket,
+  trackMedia,
+  trackFilterUsage,
+} from "./track";

--- a/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/session.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/session.js
@@ -1,0 +1,20 @@
+
+const SID_KEY = 'ga_session_id';
+const LOGIN_SENT_KEY = 'ga_login_sent';
+
+export function getSessionId() {
+  let sid = sessionStorage.getItem(SID_KEY);
+  if (!sid) {
+    sid = Date.now() + '_' + Math.floor(Math.random() * 1e6);
+    sessionStorage.setItem(SID_KEY, sid);
+  }
+  return sid;
+}
+
+export function wasLoginEventSent() {
+  return sessionStorage.getItem(LOGIN_SENT_KEY) === '1';
+}
+
+export function markLoginEventSent() {
+  sessionStorage.setItem(LOGIN_SENT_KEY, '1');
+}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/track.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/Analytics/track.js
@@ -1,0 +1,28 @@
+
+import { gtag } from './gtag';
+import { baseParams } from './baseParams';
+import { EV } from './events';
+
+export function trackLogin(extra = {}) {
+  gtag('event', EV.USER_LOGIN, baseParams(extra));
+}
+
+export function trackPageView(page_name, extra = {}) {
+  gtag('event', EV.PAGE_VIEW, baseParams({ page_name, ...extra }));
+}
+
+export function trackButtonClick(button_name, extra = {}) {
+  gtag('event', EV.BUTTON_CLICK, baseParams({ button_name, ...extra }));
+}
+
+export function trackSubmitTicket(extra = {}) {
+  gtag('event', EV.SUBMIT_TICKET, baseParams({ button_name: 'submit_ticket', page_name: 'new_ticket_page', ...extra }));
+}
+
+export function trackMedia(action /* 'upload_media' | 'stream_video' | 'download_image' */, extra = {}) {
+  gtag('event', action, baseParams(extra));
+}
+
+export function trackFilterUsage(filter_type, filter_value, extra = {}) {
+  gtag('event', EV.FILTER_USAGE, baseParams({ filter_type, filter_value, ...extra }));
+}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/utils/index.js
@@ -5,6 +5,9 @@ import * as locale from "./locale";
 import * as obps from "./obps";
 import * as pt from "./pt";
 import * as privacy from "./privacy";
+
+import * as analytics from "./Analytics";
+
 import PDFUtil, { downloadReceipt ,downloadPDFFromLink,downloadBill ,getFileUrl} from "./pdf";
 import getFileTypeFromFileStoreURL from "./fileType";
 import preProcessMDMSConfig from "./preProcessMDMSConfig";
@@ -381,5 +384,6 @@ export default {
   ...privacy,
   getDefaultLanguage,
   getLocaleDefault,
-  getLocaleRegion
+  getLocaleRegion,
+  analytics
 };

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/core/src/pages/employee/Login/login.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/core/src/pages/employee/Login/login.js
@@ -98,6 +98,29 @@ const Login = ({ config: propsConfig, t, isDisabled }) => {
       Digit.SessionStorage.set("Employee.tenantId", info?.tenantId);
 
       setUser({ info, ...tokens });
+
+      const rolesCsv = (info?.roles || []).map(r => r.code).join(",") || "unknown";
+      const stateId = Digit?.ULBService?.getStateId?.() || "unknown";
+      const district = info?.district || "unknown";
+      const block = info?.block || "unknown";
+      const facility = info?.facilityName || "unknown";
+      const isMobile = Digit?.Utils?.browser?.isMobile?.() ? "mobile" : "desktop";
+
+      if (typeof window.gtag === "function") {
+        window.gtag("event", "user_login", {
+          // required custom dimensions
+          user_role: rolesCsv,
+          geography_state: stateId,
+          geography_district: district,
+          geography_block: block,
+          facility_name: facility,
+          device_type: isMobile,
+          browser: navigator.userAgent,
+          os: navigator.platform || "unknown",
+          transport_type: "beacon",
+          debug_mode: true,
+        });
+      }
     } catch (err) {
       setShowToast(err?.response?.data?.error_description || "Invalid login credentials!");
       setTimeout(closeToast, 5000);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/im/src/pages/employee/ComplaintDetails.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/im/src/pages/employee/ComplaintDetails.js
@@ -115,6 +115,10 @@ const ComplaintDetailsModal = ({ workflowDetails, complaintDetails, close, popup
 
   //   }, [file]);
   useEffect(() => {
+    Digit.Utils.analytics.trackPageView("ticket_details_page", {
+      page_path: window.location?.pathname || "/ticket-details",
+      page_title: "Ticket Details",
+    });
     if (selectedAction === "REJECT") {
       const uuid = JSON.parse(sessionStorage.getItem("Digit.User"))?.value?.info?.uuid;
       let name = JSON.parse(sessionStorage.getItem("Digit.User"))?.value?.info?.name;
@@ -382,6 +386,7 @@ const ComplaintDetailsModal = ({ workflowDetails, complaintDetails, close, popup
           allowedMaxSizeInMB={5}
           acceptFiles={selectedAction === "RESOLVE" ? ".pdf, .xlsx, .docx, .doc, .jpeg, .png" : ".pdf, .jpg, .jpeg, .png"}
           ulb={complaintDetails?.incident?.tenantId || tenantId}
+          analyticsPage="ticket_details_page"
         />
         {selectedAction === "RESOLVE" ? (
           <div style={{ marginTop: "6px", fontSize: "13px", color: "#36454F" }}>{t("RESOLVE_RESOLUTION_REPORT")}</div>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/im/src/pages/employee/CreateComplaint/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/im/src/pages/employee/CreateComplaint/index.js
@@ -125,6 +125,10 @@ export const CreateComplaint = ({ parentUrl }) => {
   }, [state, mdmsData, t]);
 
   useEffect(() => {
+    Digit.Utils.analytics.trackPageView("new_ticket_page", {
+      page_path: window.location?.pathname || "/new-ticket",
+      page_title: "New Ticket",
+    });
     let tenants = Digit.SessionStorage.get("Employee.tenantId");
     setSelectTenant(tenants);
     if (selectTenant !== stateTenantId) {
@@ -308,8 +312,8 @@ export const CreateComplaint = ({ parentUrl }) => {
     !submitted && !abc && onSubmit(data);
   };
   const onSubmit = async (data) => {
+    Digit.Utils.analytics.trackSubmitTicket({ page_name: "new_ticket_page" });
     if (!canSubmit) return;
-
     const formData = {
       ...data,
       complaintType,
@@ -622,6 +626,8 @@ export const CreateComplaint = ({ parentUrl }) => {
                 acceptFiles={".png, .jpg, .jpeg, image/*"}
                 multiple={true}
                 specificFileConstraint={specificFileConstraint[1]}
+                analyticsPage="new_ticket_page"
+                mediaIntent="image"
               />
               {/* <ImageUploadHandler tenantId={tenant} uploadedImages={uploadedImages} onPhotoChange={handleUpload} disabled={disbaled}/> */}
               <div style={{ marginTop: "10px", marginBottom: "20px", fontSize: "12px", color: "#b5b4b4" }}>{t("CS_MAXIMUM_IMAGES")}</div>
@@ -648,6 +654,8 @@ export const CreateComplaint = ({ parentUrl }) => {
                 acceptFiles={".mp4, .avi, .mov, .wmv, video/*"}
                 multiple={false}
                 specificFileConstraint={specificFileConstraint[0]}
+                analyticsPage="new_ticket_page"
+                mediaIntent="video"
               />
               {/* <ImageUploadHandler tenantId={tenant} uploadedImages={uploadedImages} onPhotoChange={handleUpload} disabled={disbaled}/> */}
               <div style={{ marginTop: "10px", fontSize: "12px", color: "#b5b4b4" }}>{t("CS_MAXIMUM_VIDEOS")}</div>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/im/src/pages/employee/Inbox.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/im/src/pages/employee/Inbox.js
@@ -35,6 +35,23 @@ const Inbox = () => {
   const prevPageSizeRef = useRef(pageSize);
 
   useEffect(() => {
+    const nearingSLA = queryParams.get("nearing");
+    try {
+      if (nearingSLA === "1") {
+        Digit.Utils.analytics?.trackPageView("nearing_sla_page", {
+          page_path: window.location?.pathname || "/inbox",
+          page_title: "Nearing SLA Page",
+        });
+      } else {
+        Digit.Utils.analytics?.trackPageView("inbox_page", {
+          page_path: window.location?.pathname || "/inbox",
+          page_title: "Inbox",
+        });
+      }
+    } catch (e) {
+      console.warn("analytics: page_view tracking failed", e);
+    }
+
     history.replace({
       pathname: location.pathname,
       search: `filter=${JSON.stringify(searchParams)}&pageSize=${pageSize}&pageOffset=${pageOffset}`
@@ -90,6 +107,10 @@ const Inbox = () => {
   };
 
   const onSearch = (params = "") => {
+    Digit.Utils.analytics.trackButtonClick("search_submit", {
+      page_name: "inbox",
+      search_query: params || "empty",
+    });
     setSearchParams({ ...searchParams, search: params });
   };
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/react-components/src/atoms/UploadFile.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/react-components/src/atoms/UploadFile.js
@@ -95,7 +95,6 @@ const getCitizenStyles = (value) => {
         height: "auto",
         lineHeight: "16px",
         overflow: "hidden",
-        // minHeight: "35px",
         maxHeight: "34px",
         maxWidth: "100%",
       },
@@ -140,6 +139,10 @@ const UploadFile = (props) => {
   const [prevSate, setprevSate] = useState(null);
   const user_type = Digit.SessionStorage.get("userType");
   let extraStyles = {};
+
+  const pageName = props.analyticsPage || "new_ticket_page";
+  const mediaIntent = props.mediaIntent;
+
   const handleChange = () => {
     if (inputRef.current.files[0]) {
       setHasFile(true);
@@ -265,7 +268,18 @@ const UploadFile = (props) => {
             }}
             type={props.buttonType}
             onClick={() => {
-              inputRef.current.click();
+              // NEW: track the visible upload button click
+              try {
+                const btn =
+                  mediaIntent === "video" ? "upload_video_click" : "upload_image_click";
+                Digit?.Utils?.analytics?.trackButtonClick(btn, {
+                  page_name: pageName,
+                });
+              } catch (e) {
+                console.warn("analytics: upload_*_click failed", e);
+              }
+
+              inputRef.current?.click();
             }}
           >
             <div style={{
@@ -288,11 +302,10 @@ const UploadFile = (props) => {
         {props?.uploadedFiles?.map((file, index) => {
           const fileDetailsData = file[1];
           const fileType = fileDetailsData.file.type;
-          console.log(fileType, "fileType", file);
           const blob = new Blob([file[1].file], { type: file.type });
           const fileSrc = URL.createObjectURL(blob);
           return (
-            <div className="tag-container" style={extraStyles ? extraStyles?.tagContainerStyles : null}>
+            <div key={index} className="tag-container" style={extraStyles ? extraStyles?.tagContainerStyles : null}>
               {fileType.substring(0, 5) === "image" ? (
                 <div style={{ width: "100px", display: "flex", flexDirection: "column", flexWrap: "wrap", marginTop: "10px" }}>
                   <img src={fileSrc} alt="thumbnail" style={{ width: "100px", height: "80px" }} />
@@ -301,6 +314,24 @@ const UploadFile = (props) => {
                       ? `${fileDetailsData.file.name.substring(0, 7)}...${fileDetailsData.file.name.substring(fileDetailsData.file.name.length - 7)}`
                       : fileDetailsData.file.name}
                   </div>
+                  {/* NEW: download link to track download_image */}
+                  <a
+                    href={fileSrc}
+                    download
+                    style={{ fontSize: 12, textAlign: "center", marginTop: 4, color: "#0065ff", textDecoration: "underline" }}
+                    onClick={() => {
+                      try {
+                        Digit?.Utils?.analytics?.trackMedia("download_image", {
+                          page_name: pageName,
+                          media_type: "image",
+                        });
+                      } catch (e) {
+                        console.warn("analytics: download_image failed", e);
+                      }
+                    }}
+                  >
+                    {t("CS_COMMON_DOWNLOAD")}
+                  </a>
                 </div>
               ) : fileType.substring(0, 5) === "video" ? (
                 <div style={{ width: "fit-content", display: "flex", flexDirection: "column", flexWrap: "wrap", marginTop: "10px" }}>
@@ -309,6 +340,16 @@ const UploadFile = (props) => {
                       ref={(el) => (fileDetailsData.videoRef = el)}
                       src={fileSrc}
                       style={{ height: "100%", width: "100%" }}
+                      // NEW: track stream_video when playback starts
+                      onPlay={() => {
+                        try {
+                          Digit?.Utils?.analytics?.trackMedia("stream_video", {
+                            page_name: pageName,
+                          });
+                        } catch (e) {
+                          console.warn("analytics: stream_video failed", e);
+                        }
+                      }}
                       onClick={() => {
                         if (fileDetailsData.videoRef.paused) {
                           fileDetailsData.videoRef.play();
@@ -346,11 +387,6 @@ const UploadFile = (props) => {
                       <PlayIcon color="white" />
                     </div>
                   </div>
-
-                  {/* <div
-                    style={{ zIndex: 9999, position: "relative", top: "45%", left: '45%' }}
-                  >
-                    <PlayIcon color={'white'} /></div> */}
                   <div style={{ color: "#8F8F8F", fontSize: "12px", textAlign: "center", width: "100%" }}>
                     {fileDetailsData.file.name.length > 20
                       ? `${fileDetailsData.file.name.substring(0, 10)}...${fileDetailsData.file.name.substring(

--- a/frontend/micro-ui/web/micro-ui-internals/packages/react-components/src/molecules/MultiUploadWrapper.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/react-components/src/molecules/MultiUploadWrapper.js
@@ -98,6 +98,8 @@ const MultiUploadWrapper = ({
   ulb,
   specificFileConstraint,
   multiple = true,
+  analyticsPage,
+  mediaIntent,
 }) => {
   const FILES_UPLOADED = "FILES_UPLOADED";
   const TARGET_FILE_REMOVAL = "TARGET_FILE_REMOVAL";

--- a/frontend/micro-ui/web/public/index.html
+++ b/frontend/micro-ui/web/public/index.html
@@ -1,28 +1,35 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-      <!-- Google tag (gtagInfo.js) -->
-      <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZDFDM34WK4"></script>
-      <script>
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-
-          gtag('config', 'G-ZDFDM34WK4',{ anonymize_ip: true, debug_mode: true });
-      </script>
+<head>
+    <!-- Google tag (gtag.js) -->
+    <script
+            async
+            crossorigin="anonymous"
+            src="https://www.googletagmanager.com/gtag/js?id=<%= htmlWebpackPlugin.options.ga_id %>"
+    ></script>
+    <script>
+        window.dataLayer = window.dataLayer || []
+        function gtag() {
+            dataLayer.push(arguments)
+        }
+        gtag("js", new Date())
+        gtag("config", "<%= htmlWebpackPlugin.options.ga_id %>", {
+            anonymize_ip: true,
+        })
+    </script>
     <meta charset="utf-8" />
     <link
-      rel="icon"
-      href="https://selco-assets.s3.ap-south-1.amazonaws.com/TwoClr_horizontal_4X.png"
+            rel="icon"
+            href="https://selco-assets.s3.ap-south-1.amazonaws.com/TwoClr_horizontal_4X.png"
     />
     <link
-      href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;500;700&family=Roboto:wght@400;500;700&display=swap"
-      rel="stylesheet"
-      type="text/css"
+            href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;500;700&family=Roboto:wght@400;500;700&display=swap"
+            rel="stylesheet"
+            type="text/css"
     />
     <link
-      rel="stylesheet"
-      href="https://unpkg.com/@selco/selco-css@1.8.27/dist/index.css"
+            rel="stylesheet"
+            href="https://unpkg.com/@selco/selco-css@1.8.27/dist/index.css"
     />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -31,20 +38,20 @@
     <script src="https://unpkg.com/xlsx/dist/xlsx.full.min.js"></script>
     <link rel="manifest" href="<%= htmlWebpackPlugin.options.publicUrl %>manifest.json" />
     <!-- <script src="https://s3.ap-south-1.amazonaws.com/egov-dev-assets/globalConfigs.js"></script> -->
-  </head>
+</head>
 
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
+<body>
+<noscript>You need to enable JavaScript to run this app.</noscript>
+<div id="root"></div>
+<!--
+  This HTML file is a template.
+  If you open it directly in the browser, you will see an empty page.
 
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
+  You can add webfonts, meta tags, or analytics to this file.
+  The build step will place the bundled scripts into the <body> tag.
 
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-  </body>
+  To begin the development, run `npm start` or `yarn start`.
+  To create a production bundle, use `npm run build` or `yarn build`.
+-->
+</body>
 </html>

--- a/frontend/micro-ui/web/public/index.html
+++ b/frontend/micro-ui/web/public/index.html
@@ -1,22 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Google tag (gtag.js) -->
-    <script
-      async
-      crossorigin="anonymous"
-      src="https://www.googletagmanager.com/gtag/js?id=<%= htmlWebpackPlugin.options.ga_id %>"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || []
-      function gtag() {
-        dataLayer.push(arguments)
-      }
-      gtag("js", new Date())
-      gtag("config", "<%= htmlWebpackPlugin.options.ga_id %>", {
-        anonymize_ip: true,
-      })
-    </script>
+      <!-- Google tag (gtagInfo.js) -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZDFDM34WK4"></script>
+      <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', 'G-ZDFDM34WK4',{ anonymize_ip: true, debug_mode: true });
+      </script>
     <meta charset="utf-8" />
     <link
       rel="icon"

--- a/frontend/micro-ui/web/src/App.js
+++ b/frontend/micro-ui/web/src/App.js
@@ -38,6 +38,7 @@ const moduleReducers = (initData) => ({
 });
 
 const initDigitUI = () => {
+  Digit.Utils.analytics.loadGA();
   window.Digit.ComponentRegistryService.setupRegistry({
     PaymentModule,
     ...paymentConfigs,


### PR DESCRIPTION
### Summary
Implemented GA4 user interaction tracking across authentication, page navigation, and media-related actions to support behavioral analytics.

### Changes
- **User Actions**
  - Track `user_login` event after successful authentication with custom dimensions
    (role, geography, device, browser, OS).

- **Page Views**
  - Track `page_view` events for:
    - Inbox Page
    - New Ticket Page
    - Ticket Details Page
    - Nearing SLA Page

- **Media & Button Clicks**
  - Upload interactions:
    - `upload_image_click` / `upload_video_click` when upload buttons are pressed.
    - `upload_media` after successful file uploads (image/video).

### Notes
- All tracked events include custom parameters:
  - `user_role`, `geography_state`, `geography_district`, `geography_block`, `facility_name`,
    `device_type`, `browser`, and `os`.
- Event payloads include `page_name` context (e.g. `new_ticket_page`, `ticket_details_page`)
  for disambiguation.
- Filter usage events are not yet implemented and will be added in a follow-up commit.
