### PR TITLE
Git branching strategy

### DIFF
--- a/docs/git_branching-stratergy.md
+++ b/docs/git_branching-stratergy.md
@@ -1,0 +1,87 @@
+# Git Branching and Deployment Strategy
+
+
+
+## Visual Workflow Diagram
+
+```
+feature/*
+   |
+   v
+develop
+   |
+   v
+[Dev Environment]
+   |
+   v
+release/*        
+   |                         
+   |                        
+   v
+main  <----------------------+         hotfix/*
+   |                         |             |
+   |                         +-------------+
+   v
+[UAT Environment]
+   |
+   v
+[Production Environment]
+   (Promote UAT image, tag commit)
+```
+
+Step-by-step flow:
+1. Developers create `feature/*` branches from `develop` and merge back after review.
+2. `develop` is deployed to the **dev** environment.
+3. After QA signoff, a `release/*` branch is created and merged to `main` via PR (Once got approved by client).
+4. `main` is deployed to **uat** environment.
+5. After final signoff, the exact image tested in UAT is promoted to **production** (no rebuild), and a tag is created on `main` for reference.
+6. Hotfixes:
+    - For UAT: use `hotfix-uat-<description>` from `release/*` or `main`, merge back to both `main` and `release/*` (if open).
+    - For Production: use `hotfix-v<version>-<description>` from `main`, merge back to both `main`.
+
+
+## Branches
+- **main**: Production-ready code (protected)
+- **develop**: Latest development code (protected)
+- **feature/***: Feature branches from `develop`
+- **release/***: Release branches for UAT signoff
+- **hotfix/***: For urgent fixes on `main` or UAT
+
+## Environments
+- **dev**: Deploy from `develop`
+- **uat**: Deploy from `main` (after release PR is merged and signed off)
+- **production**: Deploy the exact image tested in UAT (no rebuild)
+
+## Workflow
+1. **Feature Development**
+    - Developers create `feature/*` branches from `develop`.
+    - Merge feature branches into `develop` after review.
+    - Code in `develop` is deployed to the **dev** environment.
+
+2. **Release Preparation**
+    - After QA signoff, create a `release/*` branch from `develop`.
+    - Raise a PR from `release/*` to `main`.
+    - Share the PR with the client for review.
+
+3. **UAT Deployment**
+    - After client signoff, merge the PR to `main`.
+    - Deploy the code from `main` to the **uat** environment.
+
+4. **Production Release**
+    - After final signoff (QA & client), promote the exact image tested in UAT to **production** (no new build).
+    - Create a Git tag (e.g., `v1.2.3`) on the corresponding commit in `main` for code reference.
+
+5. **Hotfixes**
+    - For UAT: Create `hotfix/uat-*` from `main` or `release/*`, merge back to both `main` and `develop`.
+    - For Production: Create `hotfix/v<version>-*` from `main`, merge back to both `main` and `develop`.
+
+## Best Practices
+- Always merge hotfixes back to both `main` and `develop` to avoid code drift.
+- Use clear naming conventions for branches and tags.
+
+
+---
+
+**Note:**
+- The production deployment always uses the image that was tested and signed off in UAT. The Git tag is for code traceability only.
+- No new image is built for production after UAT signoff.

--- a/docs/git_branching-stratergy.md
+++ b/docs/git_branching-stratergy.md
@@ -30,12 +30,13 @@ main  <----------------------+         hotfix/*
 ```
 
 Step-by-step flow:
-1. Developers create `feature/*` branches from `develop` and merge back after review.
+1.  Developers create `feature/*` branches from `develop` and merge back after review.
 2. `develop` is deployed to the **dev** environment.
-3. After QA signoff, a `release/*` branch is created and merged to `main` via PR (Once got approved by client).
-4. `main` is deployed to **uat** environment.
-5. After final signoff, the exact image tested in UAT is promoted to **production** (no rebuild), and a tag is created on `main` for reference.
-6. Hotfixes:
+3.  Create `release/*` from develop at the start of the sprint and update it incrementally with each feature after qa signoff
+4.  After QA signoff for sprint, the `release/*` branch is merged to `main` via PR (Once got approved by client).
+5. `main` is deployed to **uat** environment.
+6.  After final signoff, the exact image tested in UAT is promoted to **production** (no rebuild), and a tag is created on `main` for reference.
+7.  Hotfixes:
     - For UAT: use `hotfix-uat-<description>` from `release/*` or `main`, merge back to both `main` and `release/*` (if open).
     - For Production: use `hotfix-v<version>-<description>` from `main`, merge back to both `main`.
 
@@ -59,13 +60,14 @@ Step-by-step flow:
     - Code in `develop` is deployed to the **dev** environment.
 
 2. **Release Preparation**
-    - After QA signoff, create a `release/*` branch from `develop`.
+    - create a `release/*` branch from `develop` at the start of the sprint
     - Raise a PR from `release/*` to `main`.
+    - Update it incrementally with each feature after qa signoff
     - Share the PR with the client for review.
 
 3. **UAT Deployment**
     - After client signoff, merge the PR to `main`.
-    - Deploy the code from `main` to the **uat** environment.
+    - Deploy the c[ode from `main` to the **uat** env]()ironment.
 
 4. **Production Release**
     - After final signoff (QA & client), promote the exact image tested in UAT to **production** (no new build).

--- a/docs/git_branching-stratergy.md
+++ b/docs/git_branching-stratergy.md
@@ -78,7 +78,7 @@ Step-by-step flow:
     - For Production: Create `hotfix/v<version>-*` from `main`, merge back to both `main` and `develop`.
 
 ## Best Practices
-- Always merge hotfixes back to both `main` and `develop` to avoid code drift.
+- Before creating new release branch merge `main` into `develop` to avoid code drift.
 - Use clear naming conventions for branches and tags.
 
 


### PR DESCRIPTION
- UAT-tested Docker images can be promoted directly to Production without rebuilding.
- Avoid issues caused by squash merge
- Using a release branch with incremental feature commits makes code review easier and more effective.