### PR TITLE
FIX: add migration to correct spelling of subtype 'OtherFan'

### DIFF
--- a/backend/e4h-services/im-services/src/main/resources/db/migration/main/V20250918123200__correct_Othertfans.sql
+++ b/backend/e4h-services/im-services/src/main/resources/db/migration/main/V20250918123200__correct_Othertfans.sql
@@ -1,3 +1,12 @@
 UPDATE public.eg_incident_v2
 SET incidentsubtype = 'OtherFan'
 WHERE incidentsubtype = 'OthertFan';
+
+UPDATE eg_audit_logs
+SET keyvaluemap = jsonb_set(
+    keyvaluemap,
+    '{incidentSubType}',
+    '"OtherFan"',
+    false
+)
+WHERE keyvaluemap ->> 'incidentSubType' = 'OthertFan';


### PR DESCRIPTION
added flyway migration file to edit issue subType of already created tickets to 'OtherFan' from 'OthertFan' in incident and audit tables