### PR TITLE
[FIX]: Fixed facility boundary shown as block in facility details page

### DIFF
--- a/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/hooks/useFacilityDetails.js
+++ b/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/hooks/useFacilityDetails.js
@@ -151,7 +151,7 @@ const fetchFacilityDetails = async (filter, limit, offset) => {
       facilityId: activityFacilityData?.activityFacility?.facilityId,
       facilityType: facility.facility_type,
       status: activityFacilityData?.activityFacility?.status,
-      block: activityFacilityData?.activityFacility?.facility?.boundaryCode,
+      block: activityFacilityData?.activityFacility?.facility?.additionalDetails?.block,
       district: activityFacilityData?.activityFacility?.facility?.additionalDetails?.district,
       assigned: assigneeDetails.name,
     },


### PR DESCRIPTION
- Changed useFacilityDetails hook to not read facility boundary code as that of block's