### PR TITLE
Populated installation images in Installation Reviewer UI, Moved rejection reasons to MDMS (#2342)

### DIFF
--- a/frontend/installation-ui/web/micro-ui-internals/packages/css/package.json
+++ b/frontend/installation-ui/web/micro-ui-internals/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selco/installation-ui-css",
-  "version": "1.0.21",
+  "version": "1.0.23",
   "license": "MIT",
   "main": "dist/index.css",
   "author": "Adithya Katuku",

--- a/frontend/installation-ui/web/micro-ui-internals/packages/css/src/index.scss
+++ b/frontend/installation-ui/web/micro-ui-internals/packages/css/src/index.scss
@@ -949,3 +949,11 @@ input[type="number"] {
 .digit-privacy-checkbox-align {
   margin-top: 1rem !important;
 }
+
+.custom-dropdown {
+  .employee-select-wrap {
+    .options-card {
+      margin-top: 0;
+    }
+  }
+}

--- a/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/components/FacilityDetails/AddRejectionReasonModal.js
+++ b/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/components/FacilityDetails/AddRejectionReasonModal.js
@@ -2,47 +2,63 @@ import React, { useEffect, useState } from "react";
 import { Dropdown, DustbinIcon, TextArea } from "@egovernments/digit-ui-react-components";
 import CustomCloseSvg from "../CustomCloseSvg";
 
-const reasonOptions = [
-  { label: "Image Not Clear", code: "Image Not Clear" },
-  { label: "Incorrect Brand", code: "Incorrect Brand" },
-  { label: "Model Number Incorrect", code: "Model Number Incorrect" },
-  { label: "Serial Number Incorrect", code: "Serial Number Incorrect" }
-];
-
 const AddRejectionReasonModal = ({ t, onClose, onSave, rejectionReasons }) => {
 
-  const [reasonMenu, setReasonMenu] = useState(reasonOptions)
+  const tenantId = Digit.ULBService.getCurrentTenantId();
+  const [reasonOptions, setReasonOptions] = useState([]);
+  const [reasonMenu, setReasonMenu] = useState([]);
   const [reasons, setReasons] = useState([{ id: Date.now(), reason: "", comment: "" }]);
+
+  const { data: mdmsData } = Digit.Hooks.useCustomMDMS(
+    tenantId,
+    "Installation",
+    [
+      {
+        name: "RejectionReasons",
+      },
+    ],
+    {
+      enabled: !!tenantId,
+    }
+  );
 
   const addReason = () => {
     setReasons([...reasons, { id: Date.now(), reason: "", comment: "" }]);
   };
 
   useEffect(() => {
+    setReasonOptions(
+      (mdmsData?.["Installation"]?.["RejectionReasons"] || [])
+        .map((rejectionReason) => ({...rejectionReason, label: rejectionReason.name}))
+        .sort((a, b) => a.label.localeCompare(b.label))
+    )
+  }, [mdmsData]);
+
+  useEffect(() => {
     const savedRejectionCodes = rejectionReasons.map(r => r.reason);
-    const newReasonMenu = reasonMenu.filter(option => !savedRejectionCodes.includes(option.code));
+    const newReasonMenu = reasonOptions.filter(option => !savedRejectionCodes.includes(option.label));
     newReasonMenu.sort((a, b) => a.label.localeCompare(b.label));
     setReasonMenu(newReasonMenu);
-  }, [rejectionReasons]);
+  }, [rejectionReasons, reasonOptions]);
 
-  const updateReasonsMenu = (selectedReasonCodes) => {
-    const newReasonMenu = reasonMenu.filter(option => !selectedReasonCodes.includes(option.code));
+  const updateReasonsMenu = (selectedReasons) => {
+    const newReasonMenu = reasonOptions.filter(option => !selectedReasons.includes(option.label));
     newReasonMenu.sort((a, b) => a.label.localeCompare(b.label));
     setReasonMenu(newReasonMenu);
   }
 
   const updateReason = (id, key, value) => {
     const newReasons = reasons.map(r => r.id === id ? { ...r, [key]: value } : r);
-    const selectedReasonCodes = newReasons.map(r => r.reason);
+    const selectedReasons = newReasons.map(r => r.reason);
     setReasons(newReasons);
-    updateReasonsMenu(selectedReasonCodes);
+    updateReasonsMenu(selectedReasons);
   };
 
   const deleteReason = (id) => {
     const newReasons = reasons.filter(r => r.id !== id);
-    const selectedReasonCodes = newReasons.map(r => r.reason);
+    const selectedReasons = newReasons.map(r => r.reason);
     setReasons(newReasons);
-    updateReasonsMenu(selectedReasonCodes);
+    updateReasonsMenu(selectedReasons);
   };
 
   const handleSave = () => {
@@ -75,13 +91,15 @@ const AddRejectionReasonModal = ({ t, onClose, onSave, rejectionReasons }) => {
                 </button>
               )}
             </div>
-            <Dropdown
-              t={t}
-              option={reasonMenu}
-              selected={reasonMenu?.find((opt) => opt.code === reason.reason)}
-              optionKey={"label"}
-              select={(e) => updateReason(reason.id, 'reason', e.code)}
-            />
+            <div className={"custom-dropdown"}>
+              <Dropdown
+                t={t}
+                option={reasonMenu}
+                selected={reasonMenu?.find((opt) => opt.label === reason.reason)}
+                optionKey={"label"}
+                select={(e) => updateReason(reason.id, 'reason', e.label)}
+              />
+            </div>
             <TextArea
               name={"comment"}
               onChange={(e) => updateReason(reason.id, 'comment', e.target.value)}

--- a/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/components/FacilityDetails/EditRejectionReasonModal.js
+++ b/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/components/FacilityDetails/EditRejectionReasonModal.js
@@ -2,24 +2,40 @@ import React, { useEffect, useState } from "react";
 import { Dropdown, DustbinIcon, TextArea } from "@egovernments/digit-ui-react-components";
 import CustomCloseSvg from "../CustomCloseSvg";
 
-const reasonOptions = [
-  { label: "Image Not Clear", code: "Image Not Clear" },
-  { label: "Incorrect Brand", code: "Incorrect Brand" },
-  { label: "Model Number Incorrect", code: "Model Number Incorrect" },
-  { label: "Serial Number Incorrect", code: "Serial Number Incorrect" }
-];
-
 const EditRejectionReasonModal = ({ t, name, onClose, onUpdate, onDelete, existingReason, rejectionReasons }) => {
 
-  const [reasonMenu, setReasonMenu] = useState(reasonOptions)
+  const tenantId = Digit.ULBService.getCurrentTenantId();
+  const [reasonOptions, setReasonOptions] = useState([]);
+  const [reasonMenu, setReasonMenu] = useState([]);
   const [reason, setReason] = useState(existingReason);
 
+  const { data: mdmsData } = Digit.Hooks.useCustomMDMS(
+    tenantId,
+    "Installation",
+    [
+      {
+        name: "RejectionReasons",
+      },
+    ],
+    {
+      enabled: !!tenantId,
+    }
+  );
+
   useEffect(() => {
-    const savedRejectionCodes = rejectionReasons.map(r => r.reason);
-    const newReasonMenu = reasonMenu.filter(option => (option.code === existingReason.reason || !savedRejectionCodes.includes(option.code)));
+    setReasonOptions(
+      (mdmsData?.["Installation"]?.["RejectionReasons"] || [])
+        .map((rejectionReason) => ({ ...rejectionReason, label: rejectionReason.name }))
+        .sort((a, b) => a.label.localeCompare(b.label))
+    );
+  }, [mdmsData]);
+
+  useEffect(() => {
+    const savedRejectionReasons = rejectionReasons.map(r => r.reason);
+    const newReasonMenu = reasonOptions.filter(option => (option.label === existingReason.reason || !savedRejectionReasons.includes(option.label)));
     newReasonMenu.sort((a, b) => a.label.localeCompare(b.label));
     setReasonMenu(newReasonMenu);
-  }, [rejectionReasons]);
+  }, [rejectionReasons, reasonOptions]);
 
   const updateReason = (id, key, value) => {
     setReason({ ...reason, [key]: value });
@@ -56,13 +72,15 @@ const EditRejectionReasonModal = ({ t, name, onClose, onUpdate, onDelete, existi
                 <DustbinIcon />
               </button>
             </div>
-            <Dropdown
-              t={t}
-              option={reasonMenu}
-              selected={reasonMenu?.find((opt) => opt.code === reason.reason)}
-              optionKey={"label"}
-              select={(e) => updateReason(reason.id, 'reason', e.code)}
-            />
+            <div className={"custom-dropdown"}>
+              <Dropdown
+                t={t}
+                option={reasonMenu}
+                selected={reasonMenu?.find((opt) => opt.label === reason.reason)}
+                optionKey={"label"}
+                select={(e) => updateReason(reason.id, 'reason', e.label)}
+              />
+            </div>
             <TextArea
               name={"comment"}
               onChange={(e) => updateReason(reason.id, 'comment', e.target.value)}

--- a/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/components/FacilityDetails/QCActions.js
+++ b/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/components/FacilityDetails/QCActions.js
@@ -5,7 +5,7 @@ import { clearRejectionReasons } from "../../redux/actions";
 import { ActivityService } from "../../services/Activity";
 import CommonUtils from "../../utilities/CommonUtils";
 
-const QCActions = ({ t, revalidateData, setUpdatingWorkflow, aggregatedDocuments }) => {
+const QCActions = ({ t, revalidateData, setUpdatingWorkflow, workflowDocuments }) => {
 
   const dispatch = useDispatch();
   const rejectionReasons = useSelector((state) => state.qc.rejectionReasons);
@@ -27,10 +27,10 @@ const QCActions = ({ t, revalidateData, setUpdatingWorkflow, aggregatedDocuments
       await ActivityService.updateActivityFacilityWorkflow(
         selectedFacility?.id, "APPROVE",
         [], "Approved by Installation Reviewer",
-        aggregatedDocuments
+        workflowDocuments
       );
 
-      revalidateData();
+      await revalidateData();
       dispatch(clearRejectionReasons());
       setUpdatingWorkflow(false);
       setToast({
@@ -82,10 +82,10 @@ const QCActions = ({ t, revalidateData, setUpdatingWorkflow, aggregatedDocuments
       await ActivityService.updateActivityFacilityWorkflow(
         selectedFacility?.id, "REJECT_AND_ASSIGN_FOR_FIELD_QC",
         comments, "Rejected by Installation Reviewer",
-        aggregatedDocuments
+        workflowDocuments
       );
 
-      revalidateData();
+      await revalidateData();
       dispatch(clearRejectionReasons());
       setUpdatingWorkflow(false);
       setToast({
@@ -113,10 +113,10 @@ const QCActions = ({ t, revalidateData, setUpdatingWorkflow, aggregatedDocuments
       await ActivityService.updateActivityFacilityWorkflow(
         selectedFacility?.id, "FLAG_FOR_QC",
         comments, "Flagged for QC by Installation Reviewer",
-        aggregatedDocuments
+        workflowDocuments
       );
 
-      revalidateData();
+      await revalidateData();
       dispatch(clearRejectionReasons());
       setUpdatingWorkflow(false);
       setToast({

--- a/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/components/FacilityDetails/Summary.js
+++ b/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/components/FacilityDetails/Summary.js
@@ -8,7 +8,7 @@ import { setRejectionReasons } from "../../redux/actions";
 import { ImageViewer } from "@egovernments/digit-ui-react-components";
 import CustomCloseSvg from "../CustomCloseSvg";
 
-const Summary = ({ t, sectionName, section, count, specifications, details, items, images, videos, report, isReport, supportingDocuments = [] }) => {
+const Summary = ({ t, sectionName, section, count, specifications, details, items, images, videos, report, isReport, supportingDocuments = [], installationImages = [] }) => {
 
   const [expanded, setExpanded] = useState(false);
   const [showRejectionModal, setShowRejectionModal] = useState(false);
@@ -136,7 +136,7 @@ const Summary = ({ t, sectionName, section, count, specifications, details, item
 
       {expanded &&
         (isReport ? (
-          report && <SystemParameterReport file={report} supportingDocuments={supportingDocuments} />
+          report && <SystemParameterReport t={t} file={report} supportingDocuments={supportingDocuments} installationImages={installationImages} />
         ) : (
           <div style={{ padding: "20px" }}>
             <Section title={t(`QC_INSTALLATION_ASSET_COUNT`)}>
@@ -153,7 +153,6 @@ const Summary = ({ t, sectionName, section, count, specifications, details, item
               {AssetInfoItem(t(`QC_INSTALLATION_ASSET_WARRANTY_START_DATE`), details.warrantyStartDate)}
               {AssetInfoItem(t(`QC_INSTALLATION_ASSET_WARRANTY_DURATION`), details.warrantyDuration)}
               {AssetInfoItem(t(`QC_INSTALLATION_ASSET_BRAND`), t(`QC_INSTALLATION_BRAND_${details.brand}`))}
-              {AssetInfoItem(t(`QC_INSTALLATION_ASSET_MODEL_NUMBER`), details.modelNumber)}
             </Section>
 
             {section === "BATTERY" && (

--- a/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/components/FacilityDetails/SystemParameterReport.js
+++ b/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/components/FacilityDetails/SystemParameterReport.js
@@ -1,16 +1,22 @@
-import React from "react";
+import React, {useState} from "react";
 import { PdfIcon } from "@egovernments/digit-ui-svg-components";
+import { ImageViewer } from "@egovernments/digit-ui-react-components";
 import CustomFileIcon from "../Custom/CustomFileIcon";
 
-const SystemParameterReport = ({ file, supportingDocuments }) => {
+const SystemParameterReport = ({ t, file, supportingDocuments, installationImages }) => {
+
+  const [imageToView, setImageToView] = useState(null);
+
+  const supportingDocumentsPresent = supportingDocuments.length > 0;
+  const installationImagesPresent = installationImages.some(({ images }) => images.length > 0);
 
   return (
     <div style={{ padding: "20px" }}>
       <div
         style={{
-          paddingBottom: supportingDocuments.length ? "20px" : "0",
-          marginBottom: supportingDocuments.length ? "20px" : "0",
-          borderBottom: supportingDocuments.length ? "1px solid #D6D5D4" : "0",
+          paddingBottom: supportingDocumentsPresent || installationImagesPresent ? "20px" : "0",
+          marginBottom: supportingDocumentsPresent || installationImagesPresent ? "20px" : "0",
+          borderBottom: supportingDocumentsPresent || installationImagesPresent ? "1px solid #D6D5D4" : "0",
         }}
       >
         <div
@@ -43,45 +49,89 @@ const SystemParameterReport = ({ file, supportingDocuments }) => {
           </a>
         </div>
       </div>
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: "20px"
-        }}
-      >
-        {supportingDocuments?.map((supportingDocument) => (
+      {supportingDocumentsPresent && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "20px",
+            paddingBottom: installationImagesPresent ? "20px" : "0",
+            marginBottom: installationImagesPresent ? "20px" : "0",
+            borderBottom: installationImagesPresent ? "1px solid #D6D5D4" : "0",
+          }}
+        >
           <div
             style={{
-              border: "1px solid #eee",
-              borderRadius: "6px",
-              padding: "16px",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              minWidth: "fit-content",
-              width: "20%",
-              position: "relative"
+              color: "#0B3954",
+              fontSize: "20px",
             }}
           >
-            <a
-              style={{ textDecoration: "none", color: "unset" }}
-              target="_blank"
-              rel="noopener noreferrer"
-              href={supportingDocument.fileUrl}
-              download={supportingDocument.name || "supporting-doc"}
-            >
-              <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
-                <CustomFileIcon fileName={supportingDocument.name || supportingDocument.fileType} />
-                <div>
-                  <div style={{ fontWeight: "bold", fontSize: "16px" }}>{supportingDocument.name}</div>
-                  {supportingDocument?.size && <div style={{ color: "#666", fontSize: "14px" }}>{supportingDocument.size}</div>}
-                </div>
-              </div>
-            </a>
+            {t("SUPPORTING_DOCUMENTS")}
           </div>
-        ))}
-      </div>
+          {supportingDocuments?.map((supportingDocument) => (
+            <div
+              style={{
+                border: "1px solid #eee",
+                borderRadius: "6px",
+                padding: "16px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                minWidth: "fit-content",
+                width: "20%",
+                position: "relative",
+              }}
+            >
+              <a
+                style={{ textDecoration: "none", color: "unset" }}
+                target="_blank"
+                rel="noopener noreferrer"
+                href={supportingDocument.fileUrl}
+                download={supportingDocument.name || "supporting-doc"}
+              >
+                <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+                  <CustomFileIcon fileName={supportingDocument.name || supportingDocument.fileType} />
+                  <div>
+                    <div style={{ fontWeight: "bold", fontSize: "16px" }}>{supportingDocument.name}</div>
+                    {supportingDocument?.size && <div style={{ color: "#666", fontSize: "14px" }}>{supportingDocument.size}</div>}
+                  </div>
+                </div>
+              </a>
+            </div>
+          ))}
+        </div>
+      )}
+      {installationImagesPresent && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "20px",
+          }}
+        >
+          <div
+            style={{
+              color: "#0B3954",
+              fontSize: "20px",
+            }}
+          >
+            {t("INSTALLATION_IMAGES")}
+          </div>
+          {installationImages?.map((installationImage) => (
+            <div>
+              <div style={{ fontWeight: "bold" }}>{installationImage.description}</div>
+              <div style={{ display: "flex", gap: "10px", flexWrap: "wrap" }}>
+                {installationImage.images.map((image, idx) => (
+                  <div key={idx} style={{ cursor: "pointer" }} onClick={() => setImageToView(image.fileUrl)}>
+                    <img src={image.fileUrl} alt={`Installation Image - ${idx}`} style={{ width: "100px", marginTop: "8px" }} />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      {imageToView && <ImageViewer imageSrc={imageToView} onClose={() => setImageToView(null)} />}
     </div>
   );
 };

--- a/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/components/FacilityTable/Filter.js
+++ b/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/components/FacilityTable/Filter.js
@@ -114,7 +114,7 @@ const Filter = ({ t, fieldPlan, onFilterChange, projectQueryFilter, statusesList
     selected = selected || { [optionKey]: "", code: "" };
 
     return (
-      <div>
+      <div className={"custom-dropdown"}>
         <div className="filter-label">{label}</div>
         {<Dropdown t={t} option={options} selected={selected} select={(value) => select(value, key)} optionKey={optionKey} />}
 

--- a/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/hooks/useFacility.js
+++ b/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/hooks/useFacility.js
@@ -7,8 +7,8 @@ const formatFacilities = (facilities) => {
       facilityName: row?.activityFacility?.facility?.facility_name,
       facilityId: row?.activityFacility?.facilityId,
       status: row?.activityFacility?.status,
-      block: row?.activityFacility?.facility?.additionalDetails?.block,
-      district: row?.activityFacility?.facility?.additionalDetails?.district,
+      block: row?.activityFacility?.facility?.boundary?.block,
+      district: row?.activityFacility?.facility?.boundary?.district,
       assigned: row?.activityFacility?.assignedEmployeeUser?.name,
   }));
 }

--- a/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/hooks/useFacilityDetails.js
+++ b/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/hooks/useFacilityDetails.js
@@ -58,12 +58,13 @@ const generateAuditTrail = (workflow, transactions) => {
 }
 
 const getAssetAggregation = async (workflow) => {
-  const assetAggregation = {
+  const documentAggregation = {
     images: {},
     videos: {},
-    installationReportDocuments: []
+    installationReportDocuments: [],
   };
-  const documentAggregation = [];
+  const installationImages = [];
+  const workflowDocuments = [];
 
   if (
     ["SUBMIT_REPORT_A", "SUBMIT_REPORT_B", "APPROVE", "REJECT_AND_ASSIGN_FOR_FIELD_QC", "FLAG_FOR_QC"].includes(workflow?.[0]?.action)
@@ -84,33 +85,40 @@ const getAssetAggregation = async (workflow) => {
       const documentType = document.documentType;
       let documentRequired = false;
 
-      if (documentType.toUpperCase().includes("IMAGE")) {
+      if (documentType.toUpperCase().includes("INSTALLATION_IMAGE")) {
+        documentRequired = true;
+        installationImages.push({
+          imageCode: documentType.split("-")[1],
+          fileUrl,
+          ...fileDetails
+        });
+      } else if (documentType.toUpperCase().includes("IMAGE")) {
         documentRequired = true;
         const assetType = documentType.split("-")[0].toUpperCase();
-        if (assetAggregation.images[assetType]) {
-          assetAggregation.images[assetType].push(fileUrl);
+        if (documentAggregation.images[assetType]) {
+          documentAggregation.images[assetType].push(fileUrl);
         } else {
-          assetAggregation.images[assetType] = [fileUrl];
+          documentAggregation.images[assetType] = [fileUrl];
         }
       } else if (documentType.toUpperCase().includes("VIDEO")) {
         documentRequired = true;
         const assetType = documentType.split("-")[0].toUpperCase();
 
-        if (assetAggregation.videos[assetType]) {
-          assetAggregation.videos[assetType].push({
+        if (documentAggregation.videos[assetType]) {
+          documentAggregation.videos[assetType].push({
             fileUrl,
             size: fileDetails.size,
           });
         } else {
-          assetAggregation.videos[assetType] = [{
+          documentAggregation.videos[assetType] = [{
             fileUrl,
             size: fileDetails.size
           }];
         }
       } else if (workflow[0].action !== "SUBMIT_REPORT_A" && documentType.toUpperCase() === "INSTALLATION_REPORT") {
         documentRequired = true;
-        assetAggregation.installationReportDocuments = [
-          ...assetAggregation.installationReportDocuments,
+        documentAggregation.installationReportDocuments = [
+          ...documentAggregation.installationReportDocuments,
           {
             fileUrl,
             ...fileDetails
@@ -118,19 +126,20 @@ const getAssetAggregation = async (workflow) => {
         ];
       } else if (workflow[0].action !== "SUBMIT_REPORT_A" && documentType.toUpperCase() === "INSTALLATION_REPORT_BOM") {
         documentRequired = true;
-        assetAggregation.bomCompletionReport = {
+        documentAggregation.bomCompletionReport = {
           fileUrl,
           ...fileDetails
         };
       }
 
-      if (documentRequired) documentAggregation.push(document);
+      if (documentRequired) workflowDocuments.push(document);
     }
   }
 
   return {
-    assetAggregation,
     documentAggregation,
+    installationImages,
+    workflowDocuments,
   };
 }
 
@@ -142,7 +151,7 @@ const fetchFacilityDetails = async (filter, limit, offset) => {
   const facility = activityFacilityData?.activityFacility?.facility || {};
   const assigneeDetails = activityFacilityData?.activityFacility?.assignedEmployeeUser || {};
   const auditTrail = generateAuditTrail(activityFacilityData.workflow, activityFacilityData.transactions);
-  const { assetAggregation, documentAggregation } = await getAssetAggregation(activityFacilityData.workflow);
+  const { documentAggregation, installationImages, workflowDocuments } = await getAssetAggregation(activityFacilityData.workflow);
 
   return {
     facilityDetails: {
@@ -151,13 +160,14 @@ const fetchFacilityDetails = async (filter, limit, offset) => {
       facilityId: activityFacilityData?.activityFacility?.facilityId,
       facilityType: facility.facility_type,
       status: activityFacilityData?.activityFacility?.status,
-      block: activityFacilityData?.activityFacility?.facility?.additionalDetails?.block,
-      district: activityFacilityData?.activityFacility?.facility?.additionalDetails?.district,
+      block: activityFacilityData?.activityFacility?.facility?.boundary?.block,
+      district: activityFacilityData?.activityFacility?.facility?.boundary?.district,
       assigned: assigneeDetails.name,
     },
     auditTrail,
-    assetAggregation,
     documentAggregation,
+    installationImages,
+    workflowDocuments,
   }
 }
 

--- a/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/pages/employee/FacilityDetails.js
+++ b/frontend/installation-ui/web/micro-ui-internals/packages/modules/qc/src/pages/employee/FacilityDetails.js
@@ -12,6 +12,7 @@ import InfoCard from "../../components/FacilityDetails/InfoCard";
 
 const FacilityDetails = ({t}) => {
 
+  const tenantId = Digit.ULBService.getCurrentTenantId();
   const [assets, setAssets] = useState([]);
   const dispatch = useDispatch();
   const url = window.location.href;
@@ -19,9 +20,10 @@ const FacilityDetails = ({t}) => {
   const activityFacilityId = url.split("facilities/")[1].split("/")[0].split("?")[0];
   const [facilityDetails, setFacilityDetails] = useState({});
   const [auditTrail, setAuditTrail] = useState([]);
-  const [aggregatedAssets, setAggregatedAssets] = useState({});
-  const [aggregatedDocuments, setAggregatedDocuments] = useState([]);
+  const [aggregatedDocuments, setAggregatedDocuments] = useState({});
+  const [workflowDocuments, setWorkflowDocuments] = useState([]);
   const [updatingWorkflow, setUpdatingWorkflow] = useState(false);
+  const [installationImages, setInstallationImages] = useState([]);
 
   const {
     isLoading: fieldPlanDataLoading,
@@ -42,6 +44,20 @@ const FacilityDetails = ({t}) => {
 
   const { isLoading, data: assetData } = useAsset(activityFacilityId);
 
+  const { data: mdmsResponse, isLoading: mdmsLoading } = Digit.Hooks.useCustomMDMS(
+    tenantId,
+    "common-masters",
+    [
+      {
+        name: "InstallationImages",
+      },
+    ],
+    {
+      select: (data) => data,
+      enabled: !!tenantId,
+    }
+  );
+
   useEffect(() => {
     if (assetData) {
       setAssets(assetData);
@@ -58,11 +74,25 @@ const FacilityDetails = ({t}) => {
     if (facilityData) {
       setAuditTrail(facilityData.auditTrail);
       setFacilityDetails(facilityData.facilityDetails);
-      setAggregatedAssets(facilityData.assetAggregation);
       setAggregatedDocuments(facilityData.documentAggregation);
+      setWorkflowDocuments(facilityData.workflowDocuments);
       dispatch(setSelectedFacility(facilityData.facilityDetails));
     }
   }, [facilityData]);
+
+  useEffect(() => {
+    const installationImageCriteria = mdmsResponse?.["common-masters"]?.["InstallationImages"]?.[0]?.["InstallationImage"];
+    if (facilityData?.installationImages && installationImageCriteria) {
+      setInstallationImages(
+        installationImageCriteria.map((criterion) => ({
+          description: criterion.description,
+          images: facilityData?.installationImages.filter((image) => image.imageCode === criterion.code),
+          providedImagesCount: facilityData?.installationImages.filter((image) => image.imageCode === criterion.code).length,
+          requiredImagesCount: criterion["required_count"],
+        }))
+      )
+    }
+  }, [facilityData, mdmsResponse]);
 
   useEffect(() => {
     return () => {
@@ -70,14 +100,14 @@ const FacilityDetails = ({t}) => {
     }
   }, []);
 
-  if (isLoading || facilityDataLoading || fieldPlanDataLoading) {
+  if (isLoading || facilityDataLoading || fieldPlanDataLoading || mdmsLoading) {
     return <Loader />;
   }
 
-  const revalidateData = () => {
-    revalidateFieldPlans();
-    revalidateFacilities();
-    revalidateFacilityDetails();
+  const revalidateData = async () => {
+    await revalidateFieldPlans();
+    await revalidateFacilities();
+    await revalidateFacilityDetails();
   }
 
   return (
@@ -119,21 +149,22 @@ const FacilityDetails = ({t}) => {
           specifications={asset?.specifications}
           details={asset?.details}
           items={asset?.items}
-          images={aggregatedAssets.images?.[asset.assetType]}
-          videos={aggregatedAssets.videos?.[asset.assetType]}
+          images={aggregatedDocuments.images?.[asset.assetType]}
+          videos={aggregatedDocuments.videos?.[asset.assetType]}
         />
       })}
 
-      {aggregatedAssets?.bomCompletionReport && (
+      {aggregatedDocuments?.bomCompletionReport && (
         <Summary
           t={t}
           sectionName="InstallationCompletionReport"
           section="INSTALLATION_COMPLETION_REPORT"
           report={{
-            ...aggregatedAssets?.bomCompletionReport,
+            ...aggregatedDocuments?.bomCompletionReport,
             name: `${facilityDetails.facilityName}.pdf`
           }}
-          supportingDocuments={aggregatedAssets.installationReportDocuments}
+          supportingDocuments={aggregatedDocuments.installationReportDocuments}
+          installationImages={installationImages}
           isReport={true}
         />
       )}
@@ -143,7 +174,7 @@ const FacilityDetails = ({t}) => {
           t={t}
           revalidateData={revalidateData}
           setUpdatingWorkflow={setUpdatingWorkflow}
-          aggregatedDocuments={aggregatedDocuments}
+          workflowDocuments={workflowDocuments}
         />
       )}
 

--- a/frontend/installation-ui/web/package.json
+++ b/frontend/installation-ui/web/package.json
@@ -19,7 +19,7 @@
     "@egovernments/digit-ui-react-components": "1.8.24",
     "@egovernments/digit-ui-css": "1.8.41",
     "@egovernments/digit-ui-components-css": "0.2.0",
-    "@selco/installation-ui-css": "1.0.21",
+    "@selco/installation-ui-css": "1.0.23",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "jsonpath": "^1.1.1",

--- a/frontend/installation-ui/web/yarn.lock
+++ b/frontend/installation-ui/web/yarn.lock
@@ -1814,10 +1814,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@selco/installation-ui-css@1.0.21":
-  version "1.0.21"
-  resolved "https://registry.yarnpkg.com/@selco/installation-ui-css/-/installation-ui-css-1.0.21.tgz#07381f7371e099e9b0f884dc1db520d66c984feb"
-  integrity sha512-uMO6pfpvv0nMG6rUi5YP0WtxI6iZDx/qifeKQvyFYl0adBA4DUhF4gISk1m+OZaIa6IsfGWsI1FWUy+qxivmmw==
+"@selco/installation-ui-css@1.0.23":
+  version "1.0.23"
+  resolved "https://registry.yarnpkg.com/@selco/installation-ui-css/-/installation-ui-css-1.0.23.tgz#7d5de46858042092ce2515d9b3b5c9d63d4fd6d0"
+  integrity sha512-mUn4/8ByZr1D7PGxl3vEuMIWUR8i87+wUVnygSCDlg8pzS3EboqaOxopLVW+8ilOSf5XVBMB26hlGERw3PtzbA==
   dependencies:
     node-sass "4.14.1"
     normalize.css "8.0.1"


### PR DESCRIPTION
* Populated installation images along with installation completion report

* Fixed block and district names showing up as blank in facility and facility details page

* Fixed geography filter dropdown options having large top margin

* CSSv1.0.22

* Updated web's yarn lock file

* Implemented mdms data for installation reviewer's rejection reasons

* CSSv1.0.23

* Yarn lock update

* Paused toast population during refetching data after QC Actions

* Removed model number field from Facility Details page

* Fixed rejection reason options being reduced upon just selection from dropdown

* Fixed documents heading showing up in installation completion report section without any documents to populate